### PR TITLE
Fix "owner" value so links to team page work properly in DevHub

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -15,4 +15,4 @@ metadata:
 spec:
   type: documentation
   lifecycle: experimental
-  owner: group:default/citz-imb-common-code
+  owner: bcgov/citz-imb-common-code


### PR DESCRIPTION
Fix "owner" value so links to team page work properly in DevHub. Currently, the link to team owning the docs is broken in Devhub. This change will fix so it displays.a team details page when clicked.

<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  

MVP-100: Title of Ticket
-->

## 🎯 Summary

<!-- COMPLETE JIRA LINK BELOW -->  
[MVP-](https://citz-imb.atlassian.net/jira/browse/MVP-)

<!-- PROVIDE BELOW an explanation of your changes and any images to support your explanation -->


## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](/CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - I have consulted with the team if introducing a new dependency.
> - My changes generate no new warnings.
